### PR TITLE
fix: explicitly set xcode version so the correct Swift tools are used

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 'latest'
+        xcode-version: '15.3'
 
     - name: Build
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The Swift Tools in Package.Swift is set to 5.10, but the CI is using Xcode 14.2 and Swift tools 5.7.1. This PR should fix the CI, and we can discuss how far back it should support